### PR TITLE
README: fix markdown syntax and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Imaginary-Numbers-Are-Real
-Code To Accompany YouTube series [Imaginary Numbers Are Real] (https://www.youtube.com/watch?v=T647CGsuOVU&list=PLiaHhY2iBX9g6KIvZ_703G3KJXapKkNaF).
+
+Code To Accompany YouTube series
+[Imaginary Numbers Are Real](https://youtu.be/T647CGsuOVU?list=PLiaHhY2iBX9g6KIvZ_703G3KJXapKkNaF).


### PR DESCRIPTION
Spaces between a link's label and URL are not allowed anymore
since GitHub's adoption of CommonMark:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown

Also used YouTube's official link shortening service
to make the line shorter (and break the entire link into a new line).

Finally, add a blank line under the header, for readability.